### PR TITLE
Add env example and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ backend/.venv/
 # Environment variables
 .env
 .env.*
+!.env.example
 backend/.env
 
 # Testing & Coverage

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ These instructions will get you a copy of the project up and running on your loc
       ```bash
       pip install -r requirements.txt
       ```
-    *   Create a `.env` file in the `backend` directory and add your API keys:
-      ```
-      OPENAI_API_KEY="your_openai_api_key"
-      GEMINI_API_KEY="your_gemini_api_key"
+    *   Copy `.env.example` to `.env` and edit it with your API keys and desired settings:
+      ```bash
+      cp .env.example .env
+      # then open .env and update the values
       ```
 
 3.  **Run the application:**

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+OPENAI_API_KEY=your_openai_api_key
+GEMINI_API_KEY=your_gemini_api_key
+OPENAI_MODEL_NAME=o4-mini-2025-04-16
+GEMINI_MODEL_NAME=gemini-2.5-pro
+GENERATION_PROVIDER=gemini
+SUGGESTION_PROVIDER=openai


### PR DESCRIPTION
## Summary
- allow `.env.example` in gitignore
- add `.env.example` template
- update install docs to mention copying `.env.example`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688354d6d6dc832e8279fbfbe2a9e868