### PR TITLE
Add loading indicator while waiting for model output

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -27,6 +27,15 @@ function mkMsg(text, cls, isHtml = false) {
   return div;
 }
 
+function mkLoading(text, cls) {
+  const div = document.createElement('div');
+  div.className = `msg ${cls} loading`;
+  div.innerHTML = `<span class="loading-spinner"></span> ${text}`;
+  chatEl.appendChild(div);
+  scrollBottom();
+  return div;
+}
+
 function enhanceCodeBlocks(root) {
   root.querySelectorAll('pre code').forEach(code => {
     if (window.hljs) hljs.highlightElement(code);
@@ -98,6 +107,15 @@ function addRegenerateButton(msgDiv, originalMessage) {
 async function initiateFetchAndStream(messageToProcess, cachedSuggestion = null) {
   sendBtn.disabled = true;
 
+  // Loading indicators
+  let loadingSuggEl = null;
+  let loadingGenEl = null;
+  if (cachedSuggestion) {
+    loadingGenEl = mkLoading('Generating code…', 'code');
+  } else {
+    loadingSuggEl = mkLoading('Fetching suggestions…', 'sugg');
+  }
+
   // streaming state – suggestions
   let suggAgent = '';
   let suggAccumMd = '';
@@ -149,6 +167,10 @@ async function initiateFetchAndStream(messageToProcess, cachedSuggestion = null)
 
         /* ---------- suggestions flow ---------- */
         if (type === 'suggestions_chunk') {
+          if (loadingSuggEl) {
+            loadingSuggEl.remove();
+            loadingSuggEl = null;
+          }
           if (!suggMsgEl) {
             suggAgent = msg.agent;
             const initialHtml =
@@ -169,6 +191,10 @@ async function initiateFetchAndStream(messageToProcess, cachedSuggestion = null)
         }
 
         if (type === 'suggestions_end') {
+          if (loadingSuggEl) {
+            loadingSuggEl.remove();
+            loadingSuggEl = null;
+          }
           if (msg.agent === suggAgent && suggMsgEl) {
             const cursor = suggMsgEl.querySelector('.streaming-cursor');
             if (cursor) cursor.remove();
@@ -182,11 +208,18 @@ async function initiateFetchAndStream(messageToProcess, cachedSuggestion = null)
             suggMsgEl = null;
             suggContentSpan = null;
           }
+          if (!loadingGenEl) {
+            loadingGenEl = mkLoading('Generating code…', 'code');
+          }
           continue;
         }
 
         /* ---------- generated code flow ---------- */
         if (type === 'generated_code_chunk') {
+          if (loadingGenEl) {
+            loadingGenEl.remove();
+            loadingGenEl = null;
+          }
           if (!genMsgEl) {
             genAgent = msg.agent;
             const initialHtml =
@@ -224,6 +257,14 @@ async function initiateFetchAndStream(messageToProcess, cachedSuggestion = null)
 
         /* ---------- error ---------- */
         if (type === 'error') {
+          if (loadingSuggEl) {
+            loadingSuggEl.remove();
+            loadingSuggEl = null;
+          }
+          if (loadingGenEl) {
+            loadingGenEl.remove();
+            loadingGenEl = null;
+          }
           const errDiv = mkMsg(
             `**Error from ${msg.agent}:**\n\n${msg.content}`,
             'error'
@@ -255,6 +296,8 @@ async function initiateFetchAndStream(messageToProcess, cachedSuggestion = null)
     const errDiv = mkMsg('Client error: ' + err.message, 'error');
     addRegenerateButton(errDiv, messageToProcess);
   } finally {
+    if (loadingSuggEl) loadingSuggEl.remove();
+    if (loadingGenEl) loadingGenEl.remove();
     sendBtn.disabled = false;
     inputEl.focus();
   }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -228,6 +228,29 @@ pre > .copy-btn {
 
 .action-btn:disabled { opacity: 0.6; cursor: not-allowed; }
 
+/* ---------- Loading spinner ---------- */
+.msg.loading {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.loading-spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Decorative Side Images */
 #sideLogo,
 #sideIllustration {


### PR DESCRIPTION
## Summary
- add spinner styles to show model loading
- implement `mkLoading` helper in the frontend
- show a spinner while waiting for suggestions and generated code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688355183e30832eb35f4f63699b31c0