### PR TITLE
Fix README clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 1.  **Clone the repository:**
     ```bash
-    git clone https://your-repository-url.com/
+    git clone https://github.com/Likio3000/fast_next.git
     cd your-repository-directory
     ```
 


### PR DESCRIPTION
## Summary
- update README to use the GitHub repository URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d72e6e90832ea8da800907a6227b