### PR TITLE
Use dotenv for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ These instructions will get you a copy of the project up and running on your loc
 
 ## Configuration
 
-You can configure the AI providers for suggestions and code generation by setting the following environment variables in your `.env` file:
+Configuration values can be placed in a `.env` file at the project root. The backend automatically loads this file on startup using `python-dotenv`.
+You can configure the AI providers for suggestions and code generation by setting the following variables:
 
 *   `SUGGESTION_PROVIDER`: Set to `openai` or `gemini` to choose the provider for suggestions.
 *   `GENERATION_PROVIDER`: Set to `openai` or `gemini` to choose the provider for code generation.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 # backend/app/main.py
 import os, json, asyncio, logging
+from dotenv import load_dotenv
 from pathlib import Path
 from typing import AsyncGenerator, Tuple, Dict, Any
 
@@ -17,6 +18,8 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+load_dotenv()
 
 # ─────────── Prompt templates ───────────
 SUGGESTION_PROMPT = (


### PR DESCRIPTION
## Summary
- load `.env` automatically in backend
- mention automatic `.env` loading in README

## Testing
- `python -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6888d70085d0832ebca2e6ed5d623fef